### PR TITLE
[FIXED JENKINS-23583] Test result url made absolute by prepending rootUR...

### DIFF
--- a/src/main/resources/jenkins/plugins/extracolumns/TestResultColumn/column.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/TestResultColumn/column.jelly
@@ -55,7 +55,7 @@ THE SOFTWARE.
     <td data="${sortData}">
 	    <j:choose>
 	        <j:when test="${tr!=null}">
-                <a href="${job.url}lastCompletedBuild/${tr.urlName}/">
+                <a href="${rootURL}/${job.url}lastCompletedBuild/${tr.urlName}/">
                 <j:choose>
                     <j:when test="${it.totalCount==0}">
                     (${%no tests})


### PR DESCRIPTION
Fix for https://issues.jenkins-ci.org/browse/JENKINS-23583 by prepending rootURL to the test results url to prevent the duplicate /view/[viewname] appearing in the URL following the change in behaviour of job.url