### PR TITLE
support WorkflowJob aka Pipeline (Jenkinsfile)

### DIFF
--- a/src/main/java/jenkins/plugins/extracolumns/JobTypeColumn.java
+++ b/src/main/java/jenkins/plugins/extracolumns/JobTypeColumn.java
@@ -80,6 +80,8 @@ public class JobTypeColumn extends ListViewColumn {
             return Messages.JobTypeColumn_MultiConfigName();
         } else if ("FreeStyleProject".equals(simpleName)) {
             return Messages.JobTypeColumn_FreestyleName();
+        } else if ("WorkflowJob".equals(simpleName)) {
+            return Messages.JobTypeColumn_WorkflowJobName();
         } else if (item instanceof ViewJob) {
             return Messages.JobTypeColumn_ExternalName();
         }

--- a/src/main/resources/jenkins/plugins/extracolumns/Messages.properties
+++ b/src/main/resources/jenkins/plugins/extracolumns/Messages.properties
@@ -37,6 +37,7 @@ JobTypeColumn.MultiConfigName=Multi-config
 JobTypeColumn.FreestyleName=Free-style
 JobTypeColumn.ExternalName=External
 JobTypeColumn.FolderName=Folder
+JobTypeColumn.WorkflowJobName=Pipeline
 BuildDurationColumn.DisplayName=Build Duration
 BuildParametersColumn.DisplayName=Build Parameters
 LastJobConfigurationModificationColumn.DisplayName=Last Configuration Modification


### PR DESCRIPTION
Ran this snippet in the Script Console to find out why my Pipeline jobs were showing blank in the Job Type column:

    Jenkins.instance.items.findAll().each{ println it.name + " is " + it.getClass().getSimpleName() }
