### PR TITLE
Add a new column to show the cron trigger for jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It currently provides the following columns:
 * Last build node
 * Last/current build console
 * Last project configuration modification
+* Periodic build trigger
 * Project description
 * SCM type
 * Slave or label restriction

--- a/src/main/java/jenkins/plugins/extracolumns/CronTriggerColumn.java
+++ b/src/main/java/jenkins/plugins/extracolumns/CronTriggerColumn.java
@@ -1,0 +1,88 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2012, Frederic Gurr
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package jenkins.plugins.extracolumns;
+
+import java.util.Map;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.model.Job;
+import hudson.model.AbstractProject;
+
+import hudson.views.ListViewColumnDescriptor;
+import hudson.views.ListViewColumn;
+
+import hudson.triggers.Trigger;
+import hudson.triggers.TimerTrigger;
+import hudson.triggers.TriggerDescriptor;
+
+public class CronTriggerColumn extends ListViewColumn {
+
+    @DataBoundConstructor
+    public CronTriggerColumn() {
+        super();
+    }
+
+
+    public String getCronTrigger(@SuppressWarnings("rawtypes") Job job) {
+	String cronTrigger = "";
+        if (job == null) {
+	    return cronTrigger;
+        }
+
+	AbstractProject project = (AbstractProject)job;
+	Map<TriggerDescriptor, Trigger> triggers = project.getTriggers();
+
+	for (Trigger trigger : triggers.values()) {
+	    if (trigger instanceof TimerTrigger) {
+		cronTrigger = trigger.getSpec();
+		// This will look like a cron spec of the form
+		// 10 1 * * *
+	    }
+	}
+	return cronTrigger;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends ListViewColumnDescriptor {
+
+        @Override
+        public boolean shownByDefault() {
+            return false;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.CronTriggerColumn_DisplayName();
+        }
+
+        @Override
+        public String getHelpFile() {
+            return "/plugin/extra-columns/help-cron-trigger-column.html";
+        }
+
+    }
+}

--- a/src/main/java/jenkins/plugins/extracolumns/CronTriggerColumn.java
+++ b/src/main/java/jenkins/plugins/extracolumns/CronTriggerColumn.java
@@ -25,6 +25,7 @@
 package jenkins.plugins.extracolumns;
 
 import java.util.Map;
+import java.util.Calendar;
 import java.text.DateFormat;
 
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -86,9 +87,12 @@ public class CronTriggerColumn extends ListViewColumn {
 		return "";
 	    }
 	    DateFormat fmt = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL);
-	    String previous = fmt.format(ctl.previous().getTime());
-	    String next =  fmt.format(ctl.next().getTime());
-	    return Messages.CronTriggerColumn_ToolTipFormat(previous, next);
+	    Calendar previous = ctl.previous();
+	    Calendar next = ctl.next();
+	    if (null == previous || null == next) {
+		return "";
+	    }
+	    return Messages.CronTriggerColumn_ToolTipFormat(fmt.format(previous.getTime()), fmt.format(next.getTime()));
 	} catch (antlr.ANTLRException ex) {
 	    // ignore
 	}

--- a/src/main/java/jenkins/plugins/extracolumns/CronTriggerColumn.java
+++ b/src/main/java/jenkins/plugins/extracolumns/CronTriggerColumn.java
@@ -74,7 +74,7 @@ public class CronTriggerColumn extends ListViewColumn {
 
     public String getCronTriggerToolTip(@SuppressWarnings("rawtypes") Job job) {
 	String cronTrigger = getCronTrigger(job);
-	if (job == null || cronTrigger.isEmpty()) {
+	if (null == job || cronTrigger.isEmpty()) {
 	    return "";
 	}
 
@@ -82,6 +82,9 @@ public class CronTriggerColumn extends ListViewColumn {
 	    // The logic here follows the one used in TimerTrigger to show a similar
 	    // message in the job configuration page
 	    CronTabList ctl = CronTabList.create(cronTrigger, Hash.from(job.getFullName()));
+	    if (null == ctl) {
+		return "";
+	    }
 	    DateFormat fmt = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL);
 	    String previous = fmt.format(ctl.previous().getTime());
 	    String next =  fmt.format(ctl.next().getTime());

--- a/src/main/java/jenkins/plugins/extracolumns/CronTriggerColumn.java
+++ b/src/main/java/jenkins/plugins/extracolumns/CronTriggerColumn.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2012, Frederic Gurr
+ * Copyright (c) 2017, Sanketh Indarapu
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -46,6 +46,8 @@ import hudson.scheduler.Hash;
 
 public class CronTriggerColumn extends ListViewColumn {
 
+    public final static String DEFAULT_TRIGGER = "N/A";
+
     @DataBoundConstructor
     public CronTriggerColumn() {
         super();
@@ -53,7 +55,7 @@ public class CronTriggerColumn extends ListViewColumn {
 
 
     public String getCronTrigger(@SuppressWarnings("rawtypes") Job job) {
-	String cronTrigger = "";
+	String cronTrigger = DEFAULT_TRIGGER;
         if (job == null) {
 	    return cronTrigger;
         }
@@ -74,30 +76,36 @@ public class CronTriggerColumn extends ListViewColumn {
     }
 
     public String getCronTriggerToolTip(@SuppressWarnings("rawtypes") Job job) {
+	String toolTip = DEFAULT_TRIGGER;
+	
+	if (job == null) {
+	    return toolTip;
+	}
+	
 	String cronTrigger = getCronTrigger(job);
-	if (null == job || cronTrigger.isEmpty()) {
-	    return "";
+	if (cronTrigger == null || cronTrigger.isEmpty() || cronTrigger == DEFAULT_TRIGGER) {
+	    return toolTip;
 	}
 
 	try {
 	    // The logic here follows the one used in TimerTrigger to show a similar
 	    // message in the job configuration page
 	    CronTabList ctl = CronTabList.create(cronTrigger, Hash.from(job.getFullName()));
-	    if (null == ctl) {
-		return "";
+	    if (ctl == null) {
+		return toolTip;
 	    }
 	    DateFormat fmt = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL);
 	    Calendar previous = ctl.previous();
 	    Calendar next = ctl.next();
-	    if (null == previous || null == next) {
-		return "";
+	    if (previous == null || next == null) {
+		return toolTip;
 	    }
 	    return Messages.CronTriggerColumn_ToolTipFormat(fmt.format(previous.getTime()), fmt.format(next.getTime()));
 	} catch (antlr.ANTLRException ex) {
 	    // ignore
 	}
 
-	return "";
+	return toolTip;
     }
 
     @Extension

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -3,5 +3,5 @@
   This view is used to render the installed plugins page.
 -->
 <div>
-  This is a general listview-column plugin that currently contains the following columns: Test Result, Configure Project button, Disable/Enable Project button, Project Description, Build Description &amp; SCM Type.
+  This is a general listview-column plugin that currently contains the following columns: Test Result, Configure Project button, Disable/Enable Project button, Project Description, Build Description, SCM Type &amp; Cron Trigger.
 </div>

--- a/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/column.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/column.jelly
@@ -1,7 +1,7 @@
 <!--
   The MIT License
 
-  Copyright (c) 2012, Frederic Gurr
+  Copyright (c) 2017, Sanketh Indarapu
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
@@ -24,9 +24,9 @@
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-  <j:set var="cronTrigger" value="${it.getCronTrigger(job)}"/>
-  <j:set var="cronTriggerToolTip" value="${it.getCronTriggerToolTip(job)}"/>
-<td tooltip="${cronTriggerToolTip}">
-  ${cronTrigger}
+
+<td tooltip="${it.getCronTriggerToolTip(job)}">
+  ${it.getCronTrigger(job)}
 </td>
+
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/column.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/column.jelly
@@ -1,0 +1,31 @@
+<!--
+  The MIT License
+
+  Copyright (c) 2012, Frederic Gurr
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+  <j:set var="cronTrigger" value="${it.getCronTrigger(job)}"/>
+<td>
+  ${cronTrigger}
+</td>
+</j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/column.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/column.jelly
@@ -25,7 +25,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
   <j:set var="cronTrigger" value="${it.getCronTrigger(job)}"/>
-<td>
+  <j:set var="cronTriggerToolTip" value="${it.getCronTriggerToolTip(job)}"/>
+<td tooltip="${cronTriggerToolTip}">
   ${cronTrigger}
 </td>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/columnHeader.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/columnHeader.jelly
@@ -1,0 +1,30 @@
+<!--
+  The MIT License
+
+  Copyright (c) 2012, Frederic Gurr
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+  <th>
+    ${%CronTriggerColumn.Header}
+  </th>
+</j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/columnHeader.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/columnHeader.jelly
@@ -1,7 +1,7 @@
 <!--
   The MIT License
 
-  Copyright (c) 2012, Frederic Gurr
+  Copyright (c) 2017, Sanketh Indarapu
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/columnHeader.properties
+++ b/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/columnHeader.properties
@@ -1,7 +1,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2012, Frederic Gurr
+# Copyright (c) 2017, Sanketh Indarapu
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/columnHeader.properties
+++ b/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/columnHeader.properties
@@ -1,0 +1,25 @@
+#
+# The MIT License
+#
+# Copyright (c) 2012, Frederic Gurr
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+CronTriggerColumn.Header=Periodic Build Trigger

--- a/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/config.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/config.jelly
@@ -1,0 +1,36 @@
+<!--
+  The MIT License
+
+  Copyright (c) 2012, Frederic Gurr
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+    xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+    xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+    <f:block>
+        <table>
+            <tr>
+                <td colspan="3">${%This column shows the periodic build trigger for the job in cron format}</td>
+            </tr>
+        </table>
+    </f:block>
+</j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/config.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/config.jelly
@@ -1,7 +1,7 @@
 <!--
   The MIT License
 
-  Copyright (c) 2012, Frederic Gurr
+  Copyright (c) 2017, Sanketh Indarapu
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/jenkins/plugins/extracolumns/Messages.properties
+++ b/src/main/resources/jenkins/plugins/extracolumns/Messages.properties
@@ -45,4 +45,4 @@ LastJobConfigurationModificationColumn.DisplayName=Last Configuration Modificati
 SlaveOrLabelColumn.DisplayName=Slave Allocation
 UserNameColumn.DisplayName=User Name
 CronTriggerColumn.DisplayName=Periodic Build Trigger
-CronTriggerColumn.ToolTipFormat=Would have last run at {0}, will next run at {1}
+CronTriggerColumn.ToolTipFormat=Would last have run at {0}; would next run at {1}.

--- a/src/main/resources/jenkins/plugins/extracolumns/Messages.properties
+++ b/src/main/resources/jenkins/plugins/extracolumns/Messages.properties
@@ -44,3 +44,4 @@ BuildParametersColumn.DisplayName=Build Parameters
 LastJobConfigurationModificationColumn.DisplayName=Last Configuration Modification
 SlaveOrLabelColumn.DisplayName=Slave Allocation
 UserNameColumn.DisplayName=User Name
+CronTriggerColumn.DisplayName=Periodic Build Trigger

--- a/src/main/resources/jenkins/plugins/extracolumns/Messages.properties
+++ b/src/main/resources/jenkins/plugins/extracolumns/Messages.properties
@@ -45,3 +45,4 @@ LastJobConfigurationModificationColumn.DisplayName=Last Configuration Modificati
 SlaveOrLabelColumn.DisplayName=Slave Allocation
 UserNameColumn.DisplayName=User Name
 CronTriggerColumn.DisplayName=Periodic Build Trigger
+CronTriggerColumn.ToolTipFormat=Would have last run at {0}, will next run at {1}

--- a/src/main/webapp/help-cron-trigger-column.html
+++ b/src/main/webapp/help-cron-trigger-column.html
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2013, Frederic Gurr
+Copyright (c) 2017, Sanketh Indarapu
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main/webapp/help-cron-trigger-column.html
+++ b/src/main/webapp/help-cron-trigger-column.html
@@ -1,0 +1,27 @@
+<!--
+The MIT License
+
+Copyright (c) 2013, Frederic Gurr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<div>
+  This column shows the periodic build trigger for the job in cron format, if it exists.<br/>
+</div>

--- a/src/main/webapp/help-cron-trigger-column.html
+++ b/src/main/webapp/help-cron-trigger-column.html
@@ -23,5 +23,6 @@ THE SOFTWARE.
 -->
 
 <div>
-  This column shows the periodic build trigger for the job in cron format, if it exists.<br/>
+  This column shows the periodic build trigger for the job in cron format, if it exists. The tooltip for the cron format value will show the previous and next build times.
+<br/>
 </div>


### PR DESCRIPTION
Most of the code here is adapted from the build description plugin. I have used other cron column plugins with jenkins and was thinking it would be convenient if the extra columns plugin also provided this functionality.

This is my first time writing a jenkins plugin, so any constructive feedback is appreciated.