### PR TITLE
Add symbol for `DescriptionColumn`

### DIFF
--- a/src/main/java/jenkins/plugins/extracolumns/DescriptionColumn.java
+++ b/src/main/java/jenkins/plugins/extracolumns/DescriptionColumn.java
@@ -24,6 +24,7 @@
 
 package jenkins.plugins.extracolumns;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import hudson.Extension;
@@ -109,6 +110,7 @@ public class DescriptionColumn extends ListViewColumn {
     }
 
     @Extension
+    @Symbol("projectDescriptionColumn")
     public static class DescriptorImpl extends ListViewColumnDescriptor {
 
         @Override


### PR DESCRIPTION
`DescriptionColumn` currently doesn't work with the [Dynamic DSL](https://github.com/jenkinsci/job-dsl-plugin/wiki/Dynamic-DSL) in Job DSL. Attempting to use it with

```groovy
descriptionColumn {
  displayName false
  trim true
  displayLength 7
  columnWidth 0
  forceWidth false
}
```

yields the following error:

```
ERROR: Found multiple extensions which provide method descriptionColumn with arguments […]: [jenkins.plugins.extracolumns.DescriptionColumn, jenkins.branch.DescriptionColumn]
```

To solve this I added a symbol to disambiguate `DescriptionColumn`. I named it `projectDescriptionColumn` because in the UI the relevant column is called "Project Description".

I verified that with this patch the following syntax works:

```groovy
projectDescriptionColumn {
  displayName false
  trim true
  displayLength 7
  columnWidth 0
  forceWidth false
}
```

CC @fredg02