### PR TITLE
Fixed broken link to the Jenkins Core Extension point in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Older versions of this plugin may not be safe to use. Please review the followin
 ## Purpose
 
 This is a plugin for the [Jenkins CI server](https://jenkins.io) which provides additional columns in the main UI screen.
-It's using the [listview-column extension](https://wiki.jenkins-ci.org/display/JENKINS/Extension+points#Extensionpoints-hudson.views.ListViewColumn).
+It's using the [listview-column extension](https://www.jenkins.io/doc/developer/extensions/jenkins-core/#listviewcolumn).
 Since additional columns do not require a lot of code, the intention is to bundle multiple columns in one plugin instead of having a separate plugin for each column.
 
 It currently provides the following columns:


### PR DESCRIPTION
The link to the extension point in the README was a broken link,  I corrected the README link and anchor.  


@fredg02 can you tell me if anything is wrong with this PR?  If it was a bug fix or something requiring a code change I would have created a bug in JIRA, forked, made a branch in the fork with the JIRA identifier, pushed then PR.  I figured a JIRA task for a broken link in the README is overkill.  Any feedback what I did wrong in process would be appreciated.

