### PR TITLE
UI refinements and code cleanup

### DIFF
--- a/src/main/java/jenkins/plugins/extracolumns/CronTriggerColumn.java
+++ b/src/main/java/jenkins/plugins/extracolumns/CronTriggerColumn.java
@@ -61,10 +61,8 @@ public class CronTriggerColumn extends ListViewColumn {
         }
 
         Map<TriggerDescriptor, Trigger<?>> triggers = null;
-        if (job instanceof AbstractProject) {
-            triggers  = ((AbstractProject<?, ?>) job).getTriggers();
-        } if (job instanceof ParameterizedJobMixIn.ParameterizedJob) {
-            triggers = ((ParameterizedJobMixIn.ParameterizedJob)job).getTriggers();
+        if (job instanceof ParameterizedJobMixIn.ParameterizedJob<?, ?> pj) {
+            triggers = pj.getTriggers();
         }
 
         if (triggers == null) {

--- a/src/main/java/jenkins/plugins/extracolumns/DescriptionColumn.java
+++ b/src/main/java/jenkins/plugins/extracolumns/DescriptionColumn.java
@@ -93,7 +93,7 @@ public class DescriptionColumn extends ListViewColumn {
             return "";
         }
 
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         if (!trimIt) {
             sb.append(job.getDescription());
         } else {

--- a/src/main/java/jenkins/plugins/extracolumns/LastBuildNodeColumn.java
+++ b/src/main/java/jenkins/plugins/extracolumns/LastBuildNodeColumn.java
@@ -44,8 +44,8 @@ public class LastBuildNodeColumn extends ListViewColumn {
 
     public String getLastBuildNode(Job<?, ?> job) {
         Run<?, ?> lastBuild = job.getLastBuild();
-        if (lastBuild instanceof AbstractBuild<?, ?>) {
-            Node builtOn = ((AbstractBuild<?, ?>) lastBuild).getBuiltOn();
+        if (lastBuild instanceof AbstractBuild<?, ?> ab) {
+            Node builtOn = ab.getBuiltOn();
             if (builtOn instanceof Jenkins) {
                 return "master";
             }
@@ -53,6 +53,17 @@ public class LastBuildNodeColumn extends ListViewColumn {
                 return builtOn.getDisplayName();
             }
         } 
+        return null;
+    }
+
+    public String getLastBuildNodeDescription(Job<?, ?> job) {
+        Run<?, ?> lastBuild = job.getLastBuild();
+        if (lastBuild instanceof AbstractBuild<?, ?> ab) {
+            Node builtOn = ab.getBuiltOn();
+            if (builtOn != null) {
+                return builtOn.getNodeDescription();
+            }
+        }
         return null;
     }
 

--- a/src/main/java/jenkins/plugins/extracolumns/SCMTypeColumn.java
+++ b/src/main/java/jenkins/plugins/extracolumns/SCMTypeColumn.java
@@ -45,22 +45,21 @@ public class SCMTypeColumn extends ListViewColumn {
     }
 
     public String getScmType(@SuppressWarnings("rawtypes") Job job) {
-        if(job instanceof AbstractProject<?, ?>) {
-            AbstractProject<?, ?> project = (AbstractProject<?, ?>) job;
+        if(job instanceof AbstractProject<?, ?> project) {
             return project.getScm().getDescriptor().getDisplayName();
         } else {
             String simpleName = job.getClass().getSimpleName();
             if ("WorkflowJob".equals(simpleName)) {
-                Jenkins instance = Jenkins.getInstance();
-                if (instance != null && instance.getPlugin("workflow-job") != null) {
+                Jenkins instance = Jenkins.get();
+                if (instance.getPlugin("workflow-job") != null) {
                     org.jenkinsci.plugins.workflow.job.WorkflowJob wfj = (org.jenkinsci.plugins.workflow.job.WorkflowJob) job;
                     Collection<? extends SCM> scms = wfj.getSCMs();
-                    if (scms.size() == 0) {
+                    if (scms.isEmpty()) {
                         return "N/A";
                     }
-                    StringBuffer sb = new StringBuffer();
+                    StringBuilder sb = new StringBuilder();
                     for (SCM scm : scms) {
-                        sb.append(scm.getDescriptor().getDisplayName() + "\n");
+                        sb.append(scm.getDescriptor().getDisplayName()).append("\n");
                     }
                     return sb.toString();
                 }

--- a/src/main/java/jenkins/plugins/extracolumns/SlaveOrLabelColumn.java
+++ b/src/main/java/jenkins/plugins/extracolumns/SlaveOrLabelColumn.java
@@ -48,13 +48,12 @@ public class SlaveOrLabelColumn extends ListViewColumn {
     }
 
     public Label getLabel(Job<?, ?> job) {
-        if(!(job instanceof AbstractProject)){
+        if(!(job instanceof AbstractProject<?, ?> ap)){
             LOGGER.finest("Not an instance of " + AbstractProject.class.getCanonicalName() + ". Cannot get info.");
             return null;
         }
         
-        AbstractProject<?, ?> project = AbstractProject.class.cast(job);
-        return project.getAssignedLabel();
+        return ap.getAssignedLabel();
     }
 
     public String getDescription(Label label) {
@@ -62,7 +61,7 @@ public class SlaveOrLabelColumn extends ListViewColumn {
             return "";
         }
         String desc = label.getDescription();
-        return (desc == null || desc.length() < 1) ? "" : "(" + desc + ")";
+        return (desc == null || desc.isEmpty()) ? "" : "(" + desc + ")";
     }
 
     @Extension

--- a/src/main/resources/jenkins/plugins/extracolumns/BuildDescriptionColumn/config.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/BuildDescriptionColumn/config.jelly
@@ -26,16 +26,11 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
     xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
     xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-    <f:block>
-        <table>
-            <tr>
-                <td colspan="3">${%This column shows the build description of the last build.}</td>
-            </tr>
-            <f:optionalBlock field="forceWidth" title="${%Force column width}" inline="true">
-                <f:entry title="${%Column width}">
-                    <f:textbox field="columnWidth" default="80" />
-                </f:entry>
-            </f:optionalBlock>
-        </table>
-    </f:block>
+    <f:entry title="${%This column shows the build description of the last build.}">
+      <f:optionalBlock field="forceWidth" title="${%Force column width}" inline="true">
+          <f:entry title="${%Column width}">
+              <f:textbox field="columnWidth" default="80" />
+          </f:entry>
+      </f:optionalBlock>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/BuildDurationColumn/column.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/BuildDurationColumn/column.jelly
@@ -56,5 +56,5 @@ THE SOFTWARE.
             </j:choose>
        </j:when>
     </j:choose>
-    <td data="${sortData}" tooltip="${naTooltip}">${buildDurationString}</td>
+  <td data="${sortData}"><span tooltip="${naTooltip}">${buildDurationString}</span></td>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/BuildDurationColumn/config.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/BuildDurationColumn/config.jelly
@@ -24,14 +24,14 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-    <f:block>
-        <p>${%This column shows the last build duration.}</p>
+        <div><p>${%This column shows the last build duration.}</p></div>
         <f:entry title="${%Show}">
-            <select name="buildDurationType" class="setting-input">
+          <div class="jenkins-select">
+            <select name="buildDurationType" class="jenkins-select__input">
                 <f:option value="0" selected="${instance.buildDurationType==0}">${%Time since build started}</f:option>
                 <f:option value="1" selected="${instance.buildDurationType==1}">${%Average duration}</f:option>
                 <f:option value="2" selected="${instance.buildDurationType==2}">${%Average duration in minutes-compact}</f:option>
             </select>
+          </div>
          </f:entry>
-    </f:block>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/BuildParametersColumn/config.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/BuildParametersColumn/config.jelly
@@ -26,12 +26,10 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
     xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
     xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-    <f:block>
-        <p>${%This column shows either all build parameters or build parameters matching a regular expression of the current/last build.}</p>
+  <div><p>${%This column shows either all build parameters or build parameters matching a regular expression of the current/last build.}</p></div>
         <f:optionalBlock field="useRegex" title="${%Use regular expression}" inline="true">
             <f:entry field="regex" title="${%Regular expression}" default="">
                 <f:textbox />
             </f:entry>
         </f:optionalBlock>
-    </f:block>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/ConfigureProjectColumn/column.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/ConfigureProjectColumn/column.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
     <td>
         <j:if test="${job.hasPermission(job.CONFIGURE)}">
             <a href="${jobBaseUrl}${job.shortUrl}configure">
-                <l:icon class="icon-gear ${subIconSizeClass}" title="${%Configure project}" alt="${%Configure project}"/>
+                <l:icon src="symbol-settings" class="${subIconSizeClass}" title="${%Configure project}" alt="${%Configure project}"/>
             </a>
         </j:if>
     </td>

--- a/src/main/resources/jenkins/plugins/extracolumns/ConfigureProjectColumn/config.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/ConfigureProjectColumn/config.jelly
@@ -24,14 +24,6 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
-    <f:block>
-        <tr>
-            <td width="50">
-                <l:icon class="icon-gear icon-xlg" title="${%Configure project icon}" alt="${%Configure project icon}" />
-            </td>
-            <td colspan="2">
-                <p>${%This column adds a shortcut to the configuration page of a project.}</p>
-            </td>
-        </tr>
-    </f:block>
+  <l:icon src="symbol-settings" class="icon-xlg" alt="${%Configure project icon}" />
+  <p>${%This column adds a shortcut to the configuration page of a project.}</p>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/column.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/column.jelly
@@ -25,8 +25,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
 
-<td tooltip="${it.getCronTriggerToolTip(job)}">
-  ${it.getCronTrigger(job)}
+<td>
+  <span tooltip="${it.getCronTriggerToolTip(job)}">${it.getCronTrigger(job)}</span>
 </td>
 
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/config.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/CronTriggerColumn/config.jelly
@@ -26,11 +26,5 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
     xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
     xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-    <f:block>
-        <table>
-            <tr>
-                <td colspan="3">${%This column shows the periodic build trigger for the job in cron format.}</td>
-            </tr>
-        </table>
-    </f:block>
+  <p>${%This column shows the periodic build trigger for the job in cron format.}</p>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/DescriptionColumn/column.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/DescriptionColumn/column.jelly
@@ -30,10 +30,10 @@
   <j:set var="widthAttribute" value="width: ${it.getColumnWidth()}px;word-wrap: break-word;white-space:normal;"/>
   <td>
     <j:if test="${it.isDisplayName()}">
-      <a href="${jobBaseUrl}${job.shortUrl}" class='model-link inside'>${relativeDisplayName != null ? relativeDisplayName : job.displayName}</a><br/>
+      <a href="${jobBaseUrl}${job.shortUrl}" class='jenkins-table__link model-link inside'>${relativeDisplayName != null ? relativeDisplayName : job.displayName}</a><br/>
     </j:if>
-    <div tooltip="${app.markupFormatter.translate(tooltipdesc)}" style="${it.isForceWidth() ? widthAttribute : null}">
-      <j:out value="${app.markupFormatter.translate(desc)}"/>
+    <div style="${it.isForceWidth() ? widthAttribute : null}">
+      <span tooltip="${app.markupFormatter.translate(tooltipdesc)}"><j:out value="${app.markupFormatter.translate(desc)}"/></span>
     </div>
   </td>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/DescriptionColumn/config.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/DescriptionColumn/config.jelly
@@ -26,26 +26,18 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
     xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
     xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-    <f:block>
-        <table>
-            <tr>
-                <td colspan="3">${%This column shows the project description.}</td>
-            </tr>
-            <tr>
-                <td colspan="3">
-                    <f:checkbox field="displayName" title="${%DescriptionColumn.DisplayName}" />
-                </td>
-            </tr>
-            <f:optionalBlock field="trim" title="${%DescriptionColumn.Trim}" inline="true">
-                <f:entry title="${%DescriptionColumn.DisplayLength}">
-                    <f:textbox field="displayLength" default="1" />
-                </f:entry>
-            </f:optionalBlock>
-            <f:optionalBlock field="forceWidth" title="${%Force column width}" inline="true">
-                <f:entry title="${%Column width}">
-                    <f:textbox field="columnWidth" default="80" />
-                </f:entry>
-            </f:optionalBlock>
-        </table>
-    </f:block>
+    <div><p>${%This column shows the project description.}</p></div>
+    <f:entry>
+      <f:checkbox field="displayName" title="${%DescriptionColumn.DisplayName}" />
+    </f:entry>
+    <f:optionalBlock field="trim" title="${%DescriptionColumn.Trim}" inline="true">
+        <f:entry title="${%DescriptionColumn.DisplayLength}">
+            <f:textbox field="displayLength" default="1" />
+        </f:entry>
+    </f:optionalBlock>
+    <f:optionalBlock field="forceWidth" title="${%Force column width}" inline="true">
+        <f:entry title="${%Column width}">
+            <f:textbox field="columnWidth" default="80" />
+        </f:entry>
+    </f:optionalBlock>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/DisableProjectColumn/config.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/DisableProjectColumn/config.jelly
@@ -24,19 +24,8 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-    <f:block>
-        <tr>
-            <td colspan="2">
-                <p>${%This column adds a button or an icon for disabling/enabling a project.}</p>
-                <table>
-                    <f:entry>
-                        <f:radio name="useIcon" checked="${instance.useIcon()}" title="${%Use icon}" value="true"/>
-                    </f:entry>
-                    <f:entry>
-                        <f:radio name="useIcon" checked="${!instance.useIcon()}" title="${%Use button}" value="false"/>
-                    </f:entry>
-                </table>
-            </td>
-        </tr>
-    </f:block>
+    <f:entry title="${%This column adds a button or an icon for disabling/enabling a project.}">
+        <f:radio name="useIcon" checked="${instance.useIcon()}" title="${%Use icon}" value="true"/>
+        <f:radio name="useIcon" checked="${!instance.useIcon()}" title="${%Use button}" value="false"/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/JobTypeColumn/config.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/JobTypeColumn/config.jelly
@@ -24,17 +24,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-    <f:block>
-        <tr>
-            <td width="50">
-                
-            </td>
-            <td colspan="2">
-                <p>${%This column shows the type of the job, eg. Free-style, Maven, Multi-config, Pipeline.}</p>
-                <f:entry>
-                    <f:checkbox field="usePronoun" title="${%Use pronoun}" />
-                </f:entry>
-            </td>
-        </tr>
-    </f:block>
+  <f:entry title="${%This column shows the type of the job, eg. Free-style, Maven, Multi-config, Pipeline.}">
+    <f:checkbox field="usePronoun" title="${%Use pronoun}" />
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/LastBuildColumn/column.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/LastBuildColumn/column.jelly
@@ -48,10 +48,10 @@ THE SOFTWARE.
     </j:choose>
     <j:choose>
         <j:when test="${it.showLink and lastBuild != null}">
-            <td data="${sortData}" tooltip="${tooltip}">${lastBuildString} - <a href="${jobBaseUrl}${job.shortUrl}${it.buildTypeUrl}/" class="model-link inside">${lastBuild.displayName}</a></td>
+          <td data="${sortData}"><span tooltip="${tooltip}">${lastBuildString}</span> <a href="${jobBaseUrl}${job.shortUrl}${it.buildTypeUrl}/" class="jenkins-table__link jenkins-table__badge model-link inside">${lastBuild.displayName}</a></td>
         </j:when>
         <j:otherwise>
-            <td data="${sortData}" tooltip="${tooltip}">${lastBuildString}</td>
+          <td data="${sortData}"><span tooltip="${tooltip}">${lastBuildString}</span></td>
         </j:otherwise>
     </j:choose>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/LastBuildColumn/config.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/LastBuildColumn/config.jelly
@@ -24,30 +24,33 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-    <f:block>
-        <p>${%This column shows the last build.}</p>
-        <f:entry title="${%Build Start/End}">
-            <select name="sortType" class="setting-input">
-                <f:option value="0" selected="${instance.sortType==0}">${%Build start}</f:option>
-                <f:option value="1" selected="${instance.sortType==1}">${%Build end}</f:option>
-            </select>
-         </f:entry>
-         <f:entry title="${%Build Selector}">
-            <select name="buildType" class="setting-input">
-                <f:option value="0" selected="${instance.buildType==0}">${%Last build}</f:option>
-                <f:option value="1" selected="${instance.buildType==1}">${%Last completed build}</f:option>
-                <f:option value="2" selected="${instance.buildType==2}">${%Last failed build}</f:option>
-                <f:option value="3" selected="${instance.buildType==3}">${%Last successful build}</f:option>
-                <f:option value="4" selected="${instance.buildType==4}">${%Last unsuccessful build}</f:option>
-                <f:option value="5" selected="${instance.buildType==5}">${%Last stable build}</f:option>
-                <f:option value="6" selected="${instance.buildType==6}">${%Last unstable build}</f:option>
-            </select>
-         </f:entry>
-         <f:entry title="${%Show relative times}">
-            <f:checkbox field="useRelative" />
-         </f:entry>
-         <f:entry title="${%Show link to build}">
-            <f:checkbox field="showLink" />
-         </f:entry>
-    </f:block>
+
+  <div><p>${%This column shows the last build.}</p></div>
+  <f:entry title="${%Build Start/End}">
+    <div class="jenkins-select">
+      <select name="sortType" class="jenkins-select__input">
+          <f:option value="0" selected="${instance.sortType==0}">${%Build start}</f:option>
+          <f:option value="1" selected="${instance.sortType==1}">${%Build end}</f:option>
+      </select>
+    </div>
+   </f:entry>
+   <f:entry title="${%Build Selector}">
+     <div class="jenkins-select">
+      <select name="buildType" class="jenkins-select__input">
+          <f:option value="0" selected="${instance.buildType==0}">${%Last build}</f:option>
+          <f:option value="1" selected="${instance.buildType==1}">${%Last completed build}</f:option>
+          <f:option value="2" selected="${instance.buildType==2}">${%Last failed build}</f:option>
+          <f:option value="3" selected="${instance.buildType==3}">${%Last successful build}</f:option>
+          <f:option value="4" selected="${instance.buildType==4}">${%Last unsuccessful build}</f:option>
+          <f:option value="5" selected="${instance.buildType==5}">${%Last stable build}</f:option>
+          <f:option value="6" selected="${instance.buildType==6}">${%Last unstable build}</f:option>
+      </select>
+     </div>
+   </f:entry>
+   <f:entry title="${%Show relative times}">
+      <f:checkbox field="useRelative" />
+   </f:entry>
+   <f:entry title="${%Show link to build}">
+      <f:checkbox field="showLink" />
+   </f:entry>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/LastBuildConsoleColumn/column.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/LastBuildConsoleColumn/column.jelly
@@ -28,7 +28,7 @@ THE SOFTWARE.
         <j:if test="${job.hasPermission(job.READ)}">
             <j:if test="${job.getLastBuild() != null}">
                 <a href="${jobBaseUrl}${job.shortUrl}lastBuild/console#footer">
-                    <l:icon class="icon-terminal ${subIconSizeClass}" title="${%Last/current build console output}" alt="${%Last/current build console output}" />
+                    <l:icon src="symbol-terminal" class="${subIconSizeClass}" tooltip="${%Last/current build console output}" alt="${%Last/current build console output}" />
                 </a>
             </j:if>
         </j:if>

--- a/src/main/resources/jenkins/plugins/extracolumns/LastBuildConsoleColumn/config.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/LastBuildConsoleColumn/config.jelly
@@ -24,14 +24,6 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout">
-    <f:block>
-        <tr>
-            <td width="50">
-                <l:icon class="icon-terminal icon-xlg" title="${%Last/current build console output icon}" alt="${%Last/current build console output icon}"/>
-            </td>
-            <td colspan="2">
-                <p>${%This column adds a shortcut to the console output of the last/current build.}</p>
-            </td>
-        </tr>
-    </f:block>
+  <l:icon src="symbol-terminal" class="icon-xlg" alt="${%Last/current build console output icon}"/>
+  <p>${%This column adds a shortcut to the console output of the last/current build.}</p>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/LastBuildNodeColumn/column.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/LastBuildNodeColumn/column.jelly
@@ -27,14 +27,14 @@ THE SOFTWARE.
     <td>
         <j:set var="node" value="${it.getLastBuildNode(job)}" />
         <j:choose>
-          <j:when test="${'master'eq node}">
-              <a href="${rootURL}/computer/(master)">Master</a>
+          <j:when test="${'master' eq node}">
+              <a href="${rootURL}/computer/(built-in)" class="jenkins-table__link model-link">${%Built-In Node}</a>
           </j:when>
           <j:when test="${node == null}">
               <span>N/A</span>
           </j:when>
           <j:otherwise>
-              <a href="${rootURL}/computer/${node}">${node}</a>
+              <a href="${rootURL}/computer/${node}" class="jenkins-table__link model-link" data-html-tooltip="${app.markupFormatter.translate(it.getLastBuildNodeDescription(job))}">${node}</a>
           </j:otherwise>
         </j:choose>
     </td>

--- a/src/main/resources/jenkins/plugins/extracolumns/LastBuildNodeColumn/config.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/LastBuildNodeColumn/config.jelly
@@ -24,14 +24,6 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout">
-    <f:block>
-        <tr>
-            <td width="50">
-                <l:icon class="icon-computer icon-xlg" title="${%Last build node icon}" alt="${%Last build node icon}"/>
-            </td>
-            <td colspan="2">
-                <p>${%This column shows the name of the node on which the last build was executed.}</p>
-            </td>
-        </tr>
-    </f:block>
+  <l:icon src="symbol-computer" class="icon-xlg" alt="${%Last build node icon}"/>
+  <p>${%This column shows the name of the node on which the last build was executed.}</p>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/LastJobConfigurationModificationColumn/config.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/LastJobConfigurationModificationColumn/config.jelly
@@ -24,7 +24,5 @@
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:block>
-        <p>${%This column shows the date of the last job configuration modification.}</p>
-    </f:block>
+   <p>${%This column shows the date of the last job configuration modification.}</p>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/SCMTypeColumn/config.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/SCMTypeColumn/config.jelly
@@ -24,7 +24,5 @@
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:block>
-        <p>${%This column shows the type of source code management that is used.}</p>
-    </f:block>
+  <p>${%This column shows the type of source code management that is used.}</p>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/SlaveOrLabelColumn/column.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/SlaveOrLabelColumn/column.jelly
@@ -30,7 +30,8 @@
     <j:choose>
       <j:when test="${label == null}">N/A</j:when>
       <j:when test="${label.equals('')}">N/A</j:when>
-      <j:when test="${label.isSelfLabel()}"><a href="${rootURL}/computer/${label.getName()}">${label.getName()}</a></j:when>
+      <j:when test="${label.isSelfLabel()}"><a href="${rootURL}/computer/${label.getName()}" class="jenkins-table__link model-link">${label.getName()}</a></j:when>
+      <j:when test="${!label.isSelfLabel()}"><a href="${rootURL}/label/${label.getName()}" class="jenkins-table__link model-link">${label.getName()}</a></j:when>
       <j:otherwise>${label.getName()} ${desc}</j:otherwise>
     </j:choose>
   </td>

--- a/src/main/resources/jenkins/plugins/extracolumns/SlaveOrLabelColumn/config.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/SlaveOrLabelColumn/config.jelly
@@ -24,7 +24,5 @@
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:block>
-        <p>${%This column shows build processor or build processor label restrictions of a job.}</p>
-    </f:block>
+  <p>${%This column shows build processor or build processor label restrictions of a job.}</p>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/TestResultColumn/config.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/TestResultColumn/config.jelly
@@ -24,17 +24,17 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-    <f:block>
-        <p>${%This column shows the test result of the last build.}</p>
-        <f:entry title="${%Test result format}">
-            <select name="testResultFormat" class="setting-input">
-                <f:option value="0" selected="${instance.testResultFormat==0}">${%TestFormat1}</f:option>
-                <f:option value="1" selected="${instance.testResultFormat==1}">${%TestFormat2}</f:option>
-                <f:option value="2" selected="${instance.testResultFormat==2}">${%Total tests}</f:option>
-                <f:option value="3" selected="${instance.testResultFormat==3}">${%Failed tests}</f:option>
-                <f:option value="4" selected="${instance.testResultFormat==4}">${%Passed tests}</f:option>
-                <f:option value="5" selected="${instance.testResultFormat==5}">${%Skipped tests}</f:option>
-            </select>
-         </f:entry>
-    </f:block>
+  <div><p>${%This column shows the test result of the last build.}</p></div>
+  <f:entry title="${%Test result format}">
+    <div class="jenkins-select">
+      <select name="testResultFormat" class="jenkins-select__input">
+          <f:option value="0" selected="${instance.testResultFormat==0}">${%TestFormat1}</f:option>
+          <f:option value="1" selected="${instance.testResultFormat==1}">${%TestFormat2}</f:option>
+          <f:option value="2" selected="${instance.testResultFormat==2}">${%Total tests}</f:option>
+          <f:option value="3" selected="${instance.testResultFormat==3}">${%Failed tests}</f:option>
+          <f:option value="4" selected="${instance.testResultFormat==4}">${%Passed tests}</f:option>
+          <f:option value="5" selected="${instance.testResultFormat==5}">${%Skipped tests}</f:option>
+      </select>
+    </div>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/UserNameColumn/column.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/UserNameColumn/column.jelly
@@ -31,10 +31,10 @@ THE SOFTWARE.
               <span>N/A</span>
           </j:when>
           <j:when test="${userIdCause != null and (userIdCause.userId == null or userIdCause.userId eq '')}">
-              <a href="${rootURL}/user/${userIdCause.userName}" title="${userIdCause.userName}">${userIdCause.userName}</a>
+              <span>${userIdCause.userName}</span>
           </j:when>
           <j:otherwise>
-              <a href="${rootURL}/user/${userIdCause.userId}" title="${userIdCause.userName} (${userIdCause.userId})">${userIdCause.userName}</a>
+              <a href="${rootURL}/user/${userIdCause.userId}" class="jenkins-table__link model-link" tooltip="${userIdCause.userName} (${userIdCause.userId})">${userIdCause.userName}</a>
           </j:otherwise>
         </j:choose>
     </td>

--- a/src/main/resources/jenkins/plugins/extracolumns/UserNameColumn/config.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/UserNameColumn/config.jelly
@@ -24,14 +24,6 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout">
-    <f:block>
-        <tr>
-            <td width="50">
-                <l:icon class="icon-user icon-xlg" title="${%User icon}" alt="${%User icon}"/>
-            </td>
-            <td colspan="2">
-                <p>${%This column shows the name of the user that started the last build.}</p>
-            </td>
-        </tr>
-    </f:block>
+  <l:icon src="symbol-people" class="icon-xlg" alt="${%User icon}"/>
+  <p>${%This column shows the name of the user that started the last build.}</p>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/WorkspaceColumn/column.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/WorkspaceColumn/column.jelly
@@ -35,8 +35,8 @@ THE SOFTWARE.
     <td>
         <j:if test="${job.hasPermission(job.WORKSPACE) and it.showWorkspace(job)}">
           <a href="${ws_url}">
-              <l:icon class="icon-folder ${subIconSizeClass}" title="${%Workspace}" alt="${%Workspace}" />
-                </a>
+              <l:icon class="icon-folder ${subIconSizeClass}" tooltip="${%Workspace}" alt="${%Workspace}" />
+          </a>
         </j:if>
     </td>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/extracolumns/WorkspaceColumn/config.jelly
+++ b/src/main/resources/jenkins/plugins/extracolumns/WorkspaceColumn/config.jelly
@@ -24,14 +24,6 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout">
-    <f:block>
-        <tr>
-            <td width="50">
-                <l:icon class="icon-folder icon-xlg" title="${%Workspace icon}" alt="${%Workspace icon}" />
-            </td>
-            <td colspan="2">
-                <p>${%This column provides a link to the workspace.}</p>
-            </td>
-        </tr>
-    </f:block>
+    <l:icon src="symbol-folder" class="icon-xlg" alt="${%Workspace icon}" />
+    <p>${%This column provides a link to the workspace.}</p>
 </j:jelly>


### PR DESCRIPTION
Refines the config screens to be be in sync with current best practices
- remove table, tr, td in config screens
- remove f:block
- apply proper styling for selects

Refine the columns
- place most tooltips on a span instead of the td to avoid that the tooltip looks misplaced when the column is much wider than the actual content
- make links to agents, job or build use the same styling as in core
- make the agent allocation a link to the label when it is not a selflabel
- add a tooltip with the agents description for the Last Build Node column (not exactly JENKINS-44437)

some code cleanup in java
- use pattern variables
- use isEmpty for lists

<!-- Please describe your pull request here. -->

### Testing done
Interactive testing

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
